### PR TITLE
Add Gitea Actions workflow for mirror auto-release

### DIFF
--- a/.gitea/workflows/README.md
+++ b/.gitea/workflows/README.md
@@ -1,0 +1,168 @@
+# Gitea Actions Workflow for VSCode Server Build & Release
+
+This workflow enables automatic builds and releases on Gitea when mirroring from GitHub.
+
+## Prerequisites
+
+- **Gitea 1.21+** (contains fixes for mirror sync triggering Actions)
+- **Gitea Actions enabled** in `app.ini`
+- **act_runner** installed and registered
+
+## Setup Guide
+
+### 1. Enable Gitea Actions
+
+Add to your Gitea `app.ini`:
+
+```ini
+[actions]
+ENABLED = true
+DEFAULT_ACTIONS_URL = https://github.com
+```
+
+Restart Gitea after changes.
+
+### 2. Install and Register Runner
+
+```bash
+# Download act_runner (check for latest version)
+wget https://gitea.com/gitea/act_runner/releases/download/v0.2.11/act_runner-0.2.11-linux-amd64
+chmod +x act_runner-0.2.11-linux-amd64
+
+# Generate runner config
+./act_runner-0.2.11-linux-amd64 generate-config > config.yaml
+
+# Register runner (get token from Gitea: Site Admin → Actions → Runners)
+./act_runner-0.2.11-linux-amd64 register \
+  --instance https://your-gitea.com \
+  --token <runner-registration-token> \
+  --name my-runner
+
+# Start runner (use systemd for production)
+./act_runner-0.2.11-linux-amd64 daemon --config config.yaml
+```
+
+### 3. Create Mirror Repository
+
+1. Go to Gitea → **+** → **New Migration**
+2. Select **GitHub** as source
+3. Enter: `https://github.com/karlorz/vscode-1.git`
+4. Check **This repository will be a mirror**
+5. Set **Mirror Interval** (e.g., `10m` for 10 minutes)
+6. Click **Migrate Repository**
+
+### 4. Enable Actions on Mirror Repository
+
+1. Go to mirrored repo → **Settings** → **Repository**
+2. Scroll to **Advanced Settings**
+3. Enable **Actions**
+4. Save
+
+### 5. Add Required Secret
+
+1. Go to repo → **Settings** → **Actions** → **Secrets**
+2. Add new secret:
+   - **Name:** `GITEA_TOKEN`
+   - **Value:** Your Gitea personal access token
+
+To create a token:
+1. Go to **User Settings** → **Applications**
+2. Generate new token with `write:repository` scope
+
+### 6. (Optional) Enable Faster Sync
+
+For faster mirroring (instead of interval):
+
+1. Go to repo → **Settings** → **Repository**
+2. Enable **Sync when new commits are pushed**
+
+Or set up a GitHub webhook to trigger Gitea sync.
+
+## How It Works
+
+```
+GitHub                          Gitea
+──────                          ─────
+push tag v1.0.0
+       │
+       └──────────────────────► Mirror syncs tag
+                                       │
+                                       ▼
+                                Actions triggered
+                                (on: push: tags: ['v*'])
+                                       │
+                                       ▼
+                                Build job runs
+                                (linux-x64, linux-arm64)
+                                       │
+                                       ▼
+                                Release job runs
+                                (creates release + uploads artifacts)
+```
+
+## Workflow Triggers
+
+| Event | Trigger |
+|-------|---------|
+| Push to `main`, `master`, `feat/**` | Build only |
+| Push tag `v*` | Build + Release |
+| Pull request to `main`, `master` | Build only |
+
+## Artifacts
+
+The workflow produces:
+
+- `vscode-server-linux-x64-web.tar.gz`
+- `vscode-server-linux-arm64-web.tar.gz` (requires arm64 runner)
+
+## Enabling ARM64 Builds
+
+1. Set up a self-hosted arm64 runner
+2. Edit `build-serve-web.yml`, uncomment the arm64 matrix entry:
+
+```yaml
+matrix:
+  include:
+    - os: ubuntu-latest
+      arch: x64
+    - os: ubuntu-latest
+      arch: arm64
+      runs-on: self-hosted-arm64  # your arm64 runner label
+```
+
+## Troubleshooting
+
+### Actions not triggering after mirror sync
+
+- Ensure Gitea is **1.21+** (earlier versions had a bug with branch/tag filters)
+- Verify Actions is enabled on the repository
+- Check runner is online: **Settings** → **Actions** → **Runners**
+
+### Release creation fails
+
+- Verify `GITEA_TOKEN` secret is set correctly
+- Token needs `write:repository` scope
+- Check Gitea API is accessible from runner
+
+### Build fails with memory errors
+
+- The workflow allocates 8GB swap space
+- Ensure runner has sufficient disk space
+- Check `NODE_OPTIONS: --max-old-space-size=8192` is set
+
+### Runner not picking up jobs
+
+```bash
+# Check runner status
+./act_runner-0.2.11-linux-amd64 daemon --config config.yaml
+
+# View logs for errors
+journalctl -u act_runner -f  # if using systemd
+```
+
+## Reference
+
+- [Gitea Actions Documentation](https://docs.gitea.com/usage/actions/overview)
+- [Gitea Mirror Documentation](https://docs.gitea.com/usage/repo-mirror)
+- [act_runner Releases](https://gitea.com/gitea/act_runner/releases)
+- [Issue #24824 - Mirror sync trigger fix](https://github.com/go-gitea/gitea/issues/24824)

--- a/.gitea/workflows/build-serve-web.yml
+++ b/.gitea/workflows/build-serve-web.yml
@@ -1,0 +1,188 @@
+name: Build VSCode Serve-Web (Gitea)
+
+on:
+  push:
+    branches: [main, master, 'feat/**']
+    tags: ['v*']
+  pull_request:
+    branches: [main, master]
+
+env:
+  NODE_VERSION: '22.20.0'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+          # Note: arm64 runner requires self-hosted runner with arm64 label
+          # Uncomment below and add your arm64 runner label
+          # - os: ubuntu-latest
+          #   arch: arm64
+          #   runs-on: self-hosted-arm64
+
+    runs-on: ${{ matrix.os }}
+    name: Build (linux-${{ matrix.arch }})
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup swap space (to handle memory-intensive builds)
+        if: runner.os == 'Linux'
+        run: |
+          # Use unique swapfile path to avoid conflicts
+          SWAPFILE="/mnt/vscode-build-swap"
+          if [ ! -f "$SWAPFILE" ]; then
+            sudo fallocate -l 8G "$SWAPFILE" || sudo dd if=/dev/zero of="$SWAPFILE" bs=1M count=8192
+            sudo chmod 600 "$SWAPFILE"
+            sudo mkswap "$SWAPFILE"
+          fi
+          sudo swapon "$SWAPFILE" || true
+          sudo swapon --show
+          free -h
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            libx11-dev \
+            libxkbfile-dev \
+            libsecret-1-dev \
+            libkrb5-dev \
+            python3 \
+            rpm
+
+      - name: Apply patches
+        run: ./scripts/apply-patches.sh
+
+      - name: Install build dependencies
+        working-directory: build
+        run: npm ci
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+
+      - name: Compile and build extensions
+        run: |
+          npm run gulp compile-build-without-mangling
+          npm run gulp compile-extensions-build
+          npm run gulp compile-extension-media-build
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      - name: Bundle and minify
+        run: npm run gulp minify-vscode-reh-web
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      - name: Build server (web)
+        run: |
+          npm run gulp vscode-reh-web-linux-${{ matrix.arch }}-min-ci
+          mv ../vscode-reh-web-linux-${{ matrix.arch }} ../vscode-server-linux-${{ matrix.arch }}-web
+
+      - name: Create archive
+        run: |
+          tar --owner=0 --group=0 -czf vscode-server-linux-${{ matrix.arch }}-web.tar.gz -C .. vscode-server-linux-${{ matrix.arch }}-web
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-server-linux-${{ matrix.arch }}-web
+          path: vscode-server-linux-${{ matrix.arch }}-web.tar.gz
+          retention-days: 30
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List artifacts
+        run: find artifacts -type f -name "*.tar.gz"
+
+      - name: Get tag name
+        id: tag
+        run: echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Check if prerelease
+        id: prerelease
+        run: |
+          if [[ "${{ steps.tag.outputs.tag_name }}" == *"-"* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Gitea Release
+        env:
+          GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
+          GITEA_SERVER: ${{ gitea.server_url }}
+          GITEA_REPO: ${{ gitea.repository }}
+        run: |
+          TAG_NAME="${{ steps.tag.outputs.tag_name }}"
+          IS_PRERELEASE=${{ steps.prerelease.outputs.is_prerelease }}
+
+          # Create release via Gitea API
+          RELEASE_RESPONSE=$(curl -s -X POST "${GITEA_SERVER}/api/v1/repos/${GITEA_REPO}/releases" \
+            -H "Authorization: token ${GITEA_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"tag_name\": \"${TAG_NAME}\",
+              \"name\": \"Release ${TAG_NAME}\",
+              \"body\": \"Automated release for ${TAG_NAME}\\n\\n## Downloads\\n- vscode-server-linux-x64-web.tar.gz\\n- vscode-server-linux-arm64-web.tar.gz\",
+              \"draft\": false,
+              \"prerelease\": ${IS_PRERELEASE}
+            }")
+
+          echo "Release response: $RELEASE_RESPONSE"
+          RELEASE_ID=$(echo "$RELEASE_RESPONSE" | jq -r '.id')
+
+          if [ "$RELEASE_ID" == "null" ] || [ -z "$RELEASE_ID" ]; then
+            echo "Failed to create release, checking if release already exists..."
+            # Try to get existing release
+            RELEASE_ID=$(curl -s "${GITEA_SERVER}/api/v1/repos/${GITEA_REPO}/releases/tags/${TAG_NAME}" \
+              -H "Authorization: token ${GITEA_TOKEN}" | jq -r '.id')
+
+            if [ "$RELEASE_ID" == "null" ] || [ -z "$RELEASE_ID" ]; then
+              echo "Could not create or find release"
+              exit 1
+            fi
+            echo "Found existing release with ID: $RELEASE_ID"
+          else
+            echo "Created release with ID: $RELEASE_ID"
+          fi
+
+          # Upload all artifacts
+          for artifact in artifacts/**/*.tar.gz; do
+            if [ -f "$artifact" ]; then
+              filename=$(basename "$artifact")
+              echo "Uploading: $filename"
+              curl -s -X POST "${GITEA_SERVER}/api/v1/repos/${GITEA_REPO}/releases/${RELEASE_ID}/assets?name=${filename}" \
+                -H "Authorization: token ${GITEA_TOKEN}" \
+                -H "Content-Type: application/octet-stream" \
+                --data-binary "@${artifact}"
+              echo "Uploaded: $filename"
+            fi
+          done
+
+          echo "Release URL: ${GITEA_SERVER}/${GITEA_REPO}/releases/tag/${TAG_NAME}"


### PR DESCRIPTION
## Summary
- Add `.gitea/workflows/build-serve-web.yml` mirroring GitHub workflow for Gitea Actions
- Add `.gitea/workflows/README.md` with complete setup guide

## Features
- Full build pipeline (compile, bundle, minify, package)
- Automatic release creation via Gitea API
- Artifact upload to releases
- Idempotent release handling (finds existing release if already created)
- Prerelease detection via tag format (`v*-*`)

## Requirements
- Gitea 1.21+ (contains mirror sync trigger fixes)
- Gitea Actions enabled with act_runner
- `GITEA_TOKEN` secret with `write:repository` scope

## How It Works
```
GitHub push tag → Gitea Mirror syncs → Gitea Actions triggers → Build + Release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)