### PR TITLE
[Crown] Implement the plan

  # Fix VS Code Web Extension Console Err...

### DIFF
--- a/patches/disable-navigator-migration-guard.diff
+++ b/patches/disable-navigator-migration-guard.diff
@@ -1,0 +1,38 @@
+Disable throwing navigator migration guard in extension host
+
+NodeJS v21+ defines navigator as a global object. VS Code added a throwing
+guard to alert extension authors about this breaking change, but it causes
+noisy console errors for extensions like openai.chatgpt that legitimately
+access navigator. Instead of throwing, provide a minimal non-throwing stub
+when Node doesn't have a native navigator (older versions) or leave it
+alone when it does (v21+).
+
+diff --git a/src/vs/workbench/api/node/extensionHostProcess.ts b/src/vs/workbench/api/node/extensionHostProcess.ts
+--- vscode.orig/src/vs/workbench/api/node/extensionHostProcess.ts
++++ vscode/src/vs/workbench/api/node/extensionHostProcess.ts
+@@ -139,12 +139,18 @@ function patchProcess(allowExit: boolean) {
+
+ // NodeJS since v21 defines navigator as a global object. This will likely surprise many extensions and potentially break them
+ // because `navigator` has historically often been used to check if running in a browser (vs running inside NodeJS)
++// Instead of throwing an error when navigator is accessed, provide a minimal stub for older Node versions
++// or leave the native navigator alone for Node v21+.
+ if (!args.supportGlobalNavigator) {
+-	Object.defineProperty(globalThis, 'navigator', {
+-		get: () => {
+-			onUnexpectedExternalError(new PendingMigrationError('navigator is now a global in nodejs, please see https://aka.ms/vscode-extensions/navigator for additional info on this error.'));
+-			return undefined;
+-		}
+-	});
++	// Only define a stub if Node doesn't already provide navigator (Node < 21)
++	if (typeof globalThis.navigator === 'undefined') {
++		Object.defineProperty(globalThis, 'navigator', {
++			value: {
++				userAgent: `Node.js/${process.version}`,
++				language: 'en'
++			},
++			writable: false,
++			configurable: false
++		});
++	}
++	// For Node >= 21, leave the native navigator as-is (no throwing getter)
+ }

--- a/patches/enable-proposed-api.diff
+++ b/patches/enable-proposed-api.diff
@@ -8,7 +8,7 @@ diff --git a/product.json b/product.json
 index af0f59dc565..c3b76b0f997 100644
 --- vscode.orig/product.json
 +++ vscode/product.json
-@@ -12,6 +12,26 @@
+@@ -12,6 +12,32 @@
  	"linkProtectionTrustedDomains": [
  		"https://open-vsx.org"
  	],
@@ -16,7 +16,13 @@ index af0f59dc565..c3b76b0f997 100644
 +		"ms-python.python": [
 +			"contribEditorContentMenu",
 +			"quickPickSortByLabel",
-+			"testObserver"
++			"testObserver",
++			"quickPickItemTooltip",
++			"terminalDataWriteEvent",
++			"terminalExecuteCommandEvent",
++			"codeActionAI",
++			"notebookReplDocument",
++			"notebookVariableProvider"
 +		],
 +		"ms-python.debugpy": [
 +			"portsAttributes",

--- a/patches/series
+++ b/patches/series
@@ -7,3 +7,4 @@ disable-cors.diff
 chat-status-null-check.diff
 default-chat-agent.diff
 skip-storage-lock.diff
+disable-navigator-migration-guard.diff


### PR DESCRIPTION
## Task

Implement the plan

  # Fix VS Code Web Extension Console Errors (karlorz/vscode-1)

  ## Summary

  Stop noisy extension-host errors from appearing in the browser console when running cmux-code (Code-OSS web) with the required preinstalled extensions (Python suite + ChatGPT +
  others installed via cmux snapshot rebuild).

  This plan updates karlorz/vscode-1 so that:

- Proposed API usage is explicitly enabled for the required extensions (so no CANNOT USE these API proposals and no “product.json enables LESS proposals” errors).
- The Node navigator migration guard stops throwing (so openai.chatgpt no longer triggers PendingMigrationError in the extension host).

  ## Context (Observed Error Classes)

1. Proposed API errors

    - Old: CANNOT USE these API proposals ... use --enable-proposed-api ...
    - New: Extension 'ms-python.python' appears in product.json but enables LESS API proposals than the extension wants

2. Node navigator guard error

    - navigator is now a global in nodejs ... PendingMigrationError
    - Stack originates from VS Code’s extension-host bootstrap (not the extension itself), then bubbles to the browser console.

  ## Approach

  Implement “Option A” from PR #4 (patch product.json via the patch series) plus a second patch to disable the navigator throwing guard in the extension host.

  This keeps changes entirely inside karlorz/vscode-1 (no need to keep editing cmux service flags across providers), and works for PVE/Morph/E2B as long as they consume the new cmux-
  code release.

  ———

  ## Changes in karlorz/vscode-1

  ### 1) Expand extensionEnabledApiProposals in product.json

  Create/adjust a patch (e.g. patches/enable-proposed-api.diff) to ensure product.json contains:

  "extensionEnabledApiProposals": {
    "ms-python.python": [
      "contribEditorContentMenu",
      "quickPickSortByLabel",
      "testObserver",
      "quickPickItemTooltip",
      "terminalDataWriteEvent",
      "terminalExecuteCommandEvent",
      "codeActionAI",
      "notebookReplDocument",
      "notebookVariableProvider"
    ],
    "ms-python.debugpy": [
      "portsAttributes",
      "debugVisualization",
      "contribViewsWelcome"
    ],
    "ms-python.vscode-python-envs": [
      "terminalShellEnv",
      "terminalDataWriteEvent"
    ],
    "openai.chatgpt": [
      "chatSessionsProvider",
      "languageModelProxy"
    ]
  }

  Notes:

- This is the minimum set to eliminate the exact proposal-related errors you’ve already observed (from the screenshot and from the newer “LESS proposals” message).
- ms-python.vscode-python-envs is typically pulled as a dependency when installing ms-python.python, so whitelisting it is required even if you don’t explicitly install it in
    configs/ide-deps.json.

  Update patches/series to include the patch (ordering: after any existing product.json patches, before any patches that might overwrite product metadata).

  ### 2) Disable the throwing navigator migration guard in the Node extension host

  Add a new patch (e.g. patches/disable-navigator-migration-guard.diff) that changes the code path that currently defines a navigator getter which throws PendingMigrationError in the
  extension host.

  Implementation requirements (decision-complete):

- Locate the guard by searching the repo for the literal message seen in the stack trace:
    - navigator is now a global in nodejs
- Modify the implementation so that accessing globalThis.navigator does not throw.
- Preferred behavior:

    1. If Node already provides globalThis.navigator, leave it as-is (no redefinition, no throwing getter).
    2. If it’s missing, define a minimal non-throwing stub:

        - userAgent string
        - language optional
        - Keep it simple; extensions typically only need existence / a couple fields.
- Ensure this patch only affects the extension-host process (not the browser workbench runtime).

  This change directly targets the new openai.chatgpt error you saw in the template-9062 run, where the stack starts in .../extensionHostProcess.js and then reaches the extension
  bundle.

  ———

  ## Public Interfaces / Compatibility

- No external API changes.
- Behavioral change: cmux-code builds will allow the above proposed APIs and will not throw the Node navigator migration error in extension host.
- Risk: enabling proposed APIs is inherently less stable; mitigate via pinning extension versions in cmux and adding validation checks (below).

  ———

  ## Verification (Must Pass)

  ### A) Local build artifact verification (vscode-1)

1. Build/release cmux-code from karlorz/vscode-1.
2. Confirm product.json in the artifact includes the extensionEnabledApiProposals block above.

  ### B) Runtime verification (PVE-LXC template)

  Use the exact flow you’ve been using:

1. Rebuild the PVE-LXC snapshots that pull the new cmux-code release.
2. Create a new instance using the new template VMID.
3. Open VS Code web and capture browser console logs (Playwright or manual).

  Acceptance criteria (recommended):

- No console errors matching:
    - PendingMigrationError: navigator is now a global in nodejs

  ———

  ## Optional Hardening (Recommended, but can be deferred)

  Add a lightweight guardrail so this doesn’t regress when extension versions bump:

- In cmux snapshot build, after installing extensions, read each installed extension’s package.json.enabledApiProposals and assert it is a subset of
    product.json.extensionEnabledApiProposals[extId] for the allowlisted IDs.
- If it’s not a subset, fail snapshot build with a clear error listing missing proposals.
    This avoids silent drift where new extension versions introduce new proposals and reintroduce console errors.

  ———

  ## Release / Rollout Steps

1. Implement the two patches in karlorz/vscode-1 and update patches/series.
2. Tag and publish a new cmux-code release (follow your existing versioning scheme).
 
 

- karlorz/vscode-1 uses a patch-series build pipeline (as desc
 
- The pinned extensions remain the ones installed today:
    - From configs/ide-deps.json: anthropic.claude-code, openai.chatgpt, ms-vscode.vscode-typescript-next, ms-python.python, ms-python.debugpy
    - Plus dependency: ms-python.vscode-python-envs
    - Plus bundled: cmux VSIX

## PR Review Summary

- **What Changed**:
  - **API Permissions**: Expanded the `extensionEnabledApiProposals` block in `product.json` (via `patches/enable-proposed-api.diff`) to whitelist specific proposed APIs for `ms-python.python`, `ms-python.debugpy`, `ms-python.vscode-python-envs`, and `openai.chatgpt`. This resolves "LESS API proposals" and "CANNOT USE" errors.
  - **Navigator Guard**: Added `patches/disable-navigator-migration-guard.diff` to `src/vs/workbench/api/node/extensionHostProcess.ts`. It replaces the `PendingMigrationError` throwing getter with a safe stub for `navigator` (userAgent, language) on Node versions < 21 and preserves the native global on Node 21+.
  - **Build Config**: Updated `patches/series` to include the new navigator patch in the build sequence.

- **Review Focus**:
  - **Proposed APIs**: Ensure the list in `product.json` matches the requirements of the latest extension versions being used; missing entries will still trigger console warnings.
  - **Node Compatibility**: Verify that the conditional check `typeof globalThis.navigator === 'undefined'` correctly handles both older and newer Node.js runtimes in the extension host process.

- **Test Plan**:
  - **Artifact Check**: Inspect the generated `product.json` in the build to confirm the new API entries are present.
  - **Console Audit**: Launch the web environment and verify the browser console is free of `PendingMigrationError` when the ChatGPT extension initializes.
  - **Functional Validation**: Run a Python Notebook or Debug session to ensure proposed APIs like `notebookVariableProvider` are active and functional.

- **Follow-ups**:
  - Consider the "Optional Hardening" mentioned in the plan: a script to automatically validate that installed extensions' `enabledApiProposals` are covered by `product.json` to prevent future regressions.